### PR TITLE
Fixes an "Maximum call stack size exceeded" issue.

### DIFF
--- a/examples/test.js
+++ b/examples/test.js
@@ -2,7 +2,21 @@ var mineflayer = require('mineflayer');
 var vec3 = mineflayer.vec3;
 var navigatePlugin = require('mineflayer-navigate')(mineflayer);
 var scaffoldPlugin = require('../')(mineflayer);
-var bot = mineflayer.createBot();
+
+
+// var bot = mineflayer.createBot();
+if(process.argv.length < 4 || process.argv.length > 6) {
+  console.log("Usage : node echo.js <host> <port> [<name>] [<password>]");
+  process.exit(1);
+}
+var bot = mineflayer.createBot({
+  host: process.argv[2],
+  port: parseInt(process.argv[3]),
+  username: process.argv[4] ? process.argv[4] : "echo",
+  password: process.argv[5],
+  verbose: true,
+});
+
 navigatePlugin(bot);
 scaffoldPlugin(bot);
 bot.scaffold.on('changeState', function(oldState, newState, reason, data) {

--- a/index.js
+++ b/index.js
@@ -279,8 +279,9 @@ function inject(bot) {
     } else if (floor.boundingBox === 'empty') {
       if (! equipBuildingBlock()) return;
       var myFloor = bot.blockAt(bot.entity.position.offset(0, -1, 0));
-      if (! placeBlock(myFloor, dir)) return;
-      changeState('improvePosition');
+      placeBlock(myFloor, dir, function(success){
+        changeState('improvePosition');
+      });
     } else {
       var done = false;
       bot.navigate.walk([newPos], function(stopReason) {
@@ -389,9 +390,15 @@ function inject(bot) {
       done = true;
     });
   }
-  function placeBlock(referenceBlock, dir) {
+  function placeBlock(referenceBlock, dir, cb) {
+    cb = cb || noop;
     if (! equipBuildingBlock()) return false;
-    bot.placeBlock(referenceBlock, dir);
+    bot.placeBlock(referenceBlock, dir, function(err){
+      if(err) 
+        cb(false);
+      else
+        cb(true);
+    });
     return true;
   }
   function equipBuildingBlock() {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "index.js",
   "devDependencies": {
     "mineflayer": "1.7.5",
-    "mineflayer-navigate": "0.0.9"
+    "mineflayer-navigate": "0.0.8"
   },
   "peerDependencies": {
-    "mineflayer": ">=0.0.35",
-    "mineflayer-navigate": ">=0.0.9"
+    "mineflayer": ">=1.7.5",
+    "mineflayer-navigate": ">=0.0.8"
   },
   "repository": "git://github.com/superjoe30/mineflayer-scaffold.git",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "mineflayer-scaffold",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "mineflayer plugin to build or break blocks to get to a certain point",
   "main": "index.js",
   "devDependencies": {
-    "mineflayer": "0.0.29",
-    "mineflayer-navigate": "0.0.8"
+    "mineflayer": "1.7.5",
+    "mineflayer-navigate": "0.0.9"
   },
   "peerDependencies": {
-    "mineflayer": ">=0.0.29",
-    "mineflayer-navigate": ">=0.0.8"
+    "mineflayer": ">=0.0.35",
+    "mineflayer-navigate": ">=0.0.9"
   },
   "repository": "git://github.com/superjoe30/mineflayer-scaffold.git",
   "keywords": [


### PR DESCRIPTION
Fixes an "Maximum call stack size exceeded" issue when placing blocks and using mineflayer 1.7.5. Caused by the placeBlock call in the moveInDirection function not accounting for the asynchronous of bot.placeBlock.
