### PR TITLE
Add vec3 to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "mineflayer": "0.0.29",
     "mineflayer-navigate": "0.0.8"
   },
+  "dependencies": {
+    "vec3": "^0.1.3"
+  },
   "peerDependencies": {
     "mineflayer": ">=0.0.29",
     "mineflayer-navigate": ">=0.0.8"


### PR DESCRIPTION
This actually fixes the https://github.com/PrismarineJS/mineflayer-scaffold/pull/10 pull request.